### PR TITLE
Check for undefined callback argument in Node.stop.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -612,7 +612,7 @@ N.stop = function stop(cb) {
 
     if (this.server) {
       this.server.close(cb);
-    } else {
+    } else if (cb) {
       setImmediate(cb);
     }
 


### PR DESCRIPTION
`npm test` fails:

```
$ npm test

> skiff-algorithm@0.8.2 test /Users/david/Documents/Toptal/clients/Eris/skiff-algorithm
> istanbul cover lab --  tests/*.js -l && istanbul check-coverage --statements 93 --functions 90 --lines 90 --branches 80



  .............................TypeError: immediate._onImmediate is not a function
    at processImmediate [as _immediateCallback] (timers.js:383:17)
.../skiff-algorithm/tests/integration.js:200
        throw err;
        ^

TypeError: immediate._onImmediate is not a function
    at processImmediate [as _immediateCallback] (timers.js:383:17)
npm ERR! Test failed.  See above for more details.
```

This patch fixes the failure.
